### PR TITLE
Create the main theme

### DIFF
--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -1,10 +1,26 @@
-import React, { Fragment } from 'react';
+import React from 'react';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      light: '#5cc8ae',
+      main: '#00be94',
+      dark: '#008a6b',
+    },
+    secondary: {
+      light: '#ffcd6a',
+      main: '#f8ba2b',
+      dark: '#e2a121',
+    },
+  },
+});
+
 const App = () => (
-  <Fragment>
+  <ThemeProvider theme={theme}>
     <CssBaseline />
-  </Fragment>
+  </ThemeProvider>
 );
 
 export default App;


### PR DESCRIPTION
For now I've added the colors of the Fellowship's logo in [1] as our primary colors and the colors of the Fellowship's logo in [2] as our secondary colors, and I haven't added a dark theme -- we can add it down the road if we want to.

This PR fixes #15.

Logos:

1. ![Fellowship's logo](https://user-images.githubusercontent.com/26309166/87339914-a0d6c100-c547-11ea-8466-392902fc1aaf.png)
2. ![Fellowship's social card](https://user-images.githubusercontent.com/26309166/87339894-974d5900-c547-11ea-8b8b-cddce2535bfc.png)
